### PR TITLE
restringindo as páginas de controle apenas para o admin

### DIFF
--- a/src/scripts/auth-guard.js
+++ b/src/scripts/auth-guard.js
@@ -1,5 +1,20 @@
 firebase.auth().onAuthStateChanged((user) => {
   if (!user) {
     window.location.href = "../../pages/tela_login";
+  } else if (user.email !== "admin@admin.com") {
+    const restrictedPages = [
+      "admin",
+      "tela_cadastro_materiais",
+      "tela_gerenciar_materiais",
+    ];
+    const currentPath = window.location.pathname.split("/");
+    currentPath.pop();
+    currentPath.shift();
+
+    restrictedPages.forEach((page) => {
+      if (currentPath.includes(page)) {
+        window.location.href = "../../pages/tela_inicial";
+      }
+    });
   }
 });


### PR DESCRIPTION
#38 Adicionando verificação para garantir que as páginas admin, cadastro de materiais e gerenciar materiais estarão disponíveis apenas para a conta de admin